### PR TITLE
Make dispatch on proc_lib and move cowboy start/stop in its own worker

### DIFF
--- a/src/seppen.erl
+++ b/src/seppen.erl
@@ -103,6 +103,11 @@ init([]) ->
         #{
             id => seppen_dispatch,
             start => {seppen_dispatch, start_link, []}
+        },
+        #{
+            id => seppen_rest,
+            start => {seppen_rest, start_link, []}
         }
+
     ],
     {ok, {#{}, Children}}.


### PR DESCRIPTION
Change dispatch to be a lightweight proc complaint to the OTP and move cowboy server management to its own gen_server (done in existing REST callback).

Moving cowboy bits mostly done because somehow when its listener starts before `proc_lib:init_ack` it breaks compliance to sup - I only managed to make sup restart new dispatch after removing cowboy bits..

This is the same reason `seppen_rest` done as `gen_server`, not on `proc_lib`, though I do not define behavior to avoid  pesky no-ops `handle_call` and `handle_cast`.

On the other hand now I monitor cowboy listener sup to restart my sup if cowboy decide to go away for some reason. Though it may be better just to error log there and let cowboy's sup to handle restarts.