### PR TITLE
Use pterms to keep hot configs

### DIFF
--- a/src/seppen_hash.erl
+++ b/src/seppen_hash.erl
@@ -4,8 +4,14 @@
 
 
 hmac(Value) ->
-    Key = erlang:atom_to_binary(erlang:get_cookie(), unicode),
-    hmac(Key, Value).
+    case persistent_term:get(seppen_key, undefined) of
+        undefined ->
+            Key = erlang:atom_to_binary(erlang:get_cookie(), unicode),
+            persistent_term:put(seppen_key, Key),
+            hmac(Key, Value);
+        Key ->
+            hmac(Key, Value)
+    end.
 
 hmac(Key, Value) ->
     crypto:mac(hmac, sha256, Key, Value).


### PR DESCRIPTION
- Keep hmac's key in pterm
- Keep hosts list in pterm (might need to revisit later)
- Attempt to rebuild nodes' map every minute